### PR TITLE
Update lair version detection to be able to detect lair 0.1.0

### DIFF
--- a/packages/holochain/default.nix
+++ b/packages/holochain/default.nix
@@ -108,17 +108,26 @@ let
             crate = "lair_keystore_api";
             inherit rev sha256 cargoSha256;
           }).src;
-          holochainKeystoreTOML = lib.trivial.importTOML
+          kitsuneTypesTOML = lib.trivial.importTOML
             "${holochainSrc}/crates/kitsune_p2p/types/Cargo.toml";
           lairKeystoreApiVersionRaw =
-            if builtins.hasAttr "lair_keystore_api" holochainKeystoreTOML.dependencies
-              then holochainKeystoreTOML.dependencies.lair_keystore_api
-            else if builtins.hasAttr "legacy_lair_client" holochainKeystoreTOML.dependencies
-              then holochainKeystoreTOML.dependencies.legacy_lair_client.version
-            else if builtins.hasAttr "lair_keystore_client_0_0" holochainKeystoreTOML.dependencies
-              then holochainKeystoreTOML.dependencies.lair_keystore_client_0_0.version
-            else builtins.abort "could not identify lair version in ${holochainSrc}/crates/holochain_keystore/Cargo.toml"
-            ;
+            if builtins.hasAttr "lair_keystore_api" kitsuneTypesTOML.dependencies
+              then kitsuneTypesTOML.dependencies.lair_keystore_api
+            else if builtins.hasAttr "legacy_lair_client" kitsuneTypesTOML.dependencies
+              then kitsuneTypesTOML.dependencies.legacy_lair_client.version
+            else if builtins.hasAttr "lair_keystore_client_0_0" kitsuneTypesTOML.dependencies
+              then kitsuneTypesTOML.dependencies.lair_keystore_client_0_0.version
+            else let
+              holochainKeystoreTOML = lib.trivial.importTOML
+                "${holochainSrc}/crates/holochain_keystore/Cargo.toml";
+            in
+              if builtins.hasAttr "lair_keystore_api" holochainKeystoreTOML.dependencies
+                then holochainKeystoreTOML.dependencies.lair_keystore_api
+              else if builtins.hasAttr "legacy_lair_client" holochainKeystoreTOML.dependencies
+                then holochainKeystoreTOML.dependencies.legacy_lair_client.version
+              else if builtins.hasAttr "lair_keystore_client_0_0" holochainKeystoreTOML.dependencies
+                then holochainKeystoreTOML.dependencies.lair_keystore_client_0_0.version
+              else builtins.abort "could not identify lair version in ${holochainSrc}/crates/kitsune_p2p/types/Cargo.toml or ${holochainSrc}/crates/holochain_keystore/Cargo.toml";
           lairKeystoreApiVersion = builtins.replaceStrings
             [ "<" ">" "=" ]
             [ ""  "" "" ]

--- a/packages/holochain/default.nix
+++ b/packages/holochain/default.nix
@@ -109,7 +109,7 @@ let
             inherit rev sha256 cargoSha256;
           }).src;
           holochainKeystoreTOML = lib.trivial.importTOML
-            "${holochainSrc}/crates/holochain_keystore/Cargo.toml";
+            "${holochainSrc}/crates/kitsune_p2p/types/Cargo.toml";
           lairKeystoreApiVersionRaw =
             if builtins.hasAttr "lair_keystore_api" holochainKeystoreTOML.dependencies
               then holochainKeystoreTOML.dependencies.lair_keystore_api


### PR DESCRIPTION
Merging this means that lair version will default to non-legacy lair for users of holochain-nixpkgs. That's probably not desired for now so feel free to wait until the community is ready for newer lair versions or to introduce a configuration mechanism where the user can select the lair version. In the meantime I will be using this branch