### PR TITLE
packages/holochain: pkgconfig -> pkg-config

### DIFF
--- a/packages/holochain/default.nix
+++ b/packages/holochain/default.nix
@@ -6,7 +6,7 @@
 , darwin
 , libsodium
 , openssl
-, pkgconfig
+, pkg-config
 , lib
 , callPackage
 , libiconv
@@ -153,7 +153,7 @@ let
       )
     ;
 
-    nativeBuildInputs = [ perl pkgconfig ] ++ lib.optionals stdenv.isDarwin [
+    nativeBuildInputs = [ perl pkg-config ] ++ lib.optionals stdenv.isDarwin [
       xcbuild
     ];
 


### PR DESCRIPTION
Attempting to use this overlay in a NixOS test will result in evaluation
errors due to
https://github.com/NixOS/nixpkgs/commit/3edde6562e19698da69a499881e0a2e4f5a497a2.