### PR TITLE
workaround(github/build): ignore build derivation errors on macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build derivations
+        continue-on-error: ${{ matrix.platform == 'macos-latest' }}
         env:
           nix_attribute: "${{ matrix.nixAttribute }}"
         run: "nix build -f . \"packages.holochain.holochainAllBinariesWithDeps.${nix_attribute}\" --extra-experimental-features nix-command"
@@ -104,6 +105,7 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build derivations
+        continue-on-error: ${{ matrix.platform == 'macos-latest' }}
         env:
           nix_attribute: "${{ matrix.nixAttribute }}"
         run: "nix build -f . \"packages.${nix_attribute}\" --extra-experimental-features nix-command"


### PR DESCRIPTION
this is currently broken and we prefer to keep CI automated